### PR TITLE
docs: fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Vana aligns incentives between data owners, developers, and data consumers. It c
 
 Learn more about the core concepts of the Vana Network by exploring these sections:
 
-<table data-card-size="large" data-view="cards"><thead><tr><th></th><th></th><th></th></tr></thead><tbody><tr><td></td><td><a href="core-concepts/network-overview/">Network Overview</a></td><td>Understand the core building blocks of the Vana ecosystem</td></tr><tr><td></td><td><a href="core-concepts/roles/">Roles</a></td><td>Explore the different participants and their role in the Vana network</td></tr><tr><td></td><td><a href="core-concepts/key-elements/">Key Elements</a></td><td>Understand how data is transformed and validated and incitives will work</td></tr></tbody></table>
+<table data-card-size="large" data-view="cards"><thead><tr><th></th><th></th><th></th></tr></thead><tbody><tr><td></td><td><a href="core-concepts/network-overview/">Network Overview</a></td><td>Understand the core building blocks of the Vana ecosystem</td></tr><tr><td></td><td><a href="core-concepts/roles/">Roles</a></td><td>Explore the different participants and their role in the Vana network</td></tr><tr><td></td><td><a href="core-concepts/key-elements/">Key Elements</a></td><td>Understand how data is transformed and validated and incentives will work</td></tr></tbody></table>
 
 To participate in the network, you can:
 

--- a/core-concepts/data-ingress/data-privacy.md
+++ b/core-concepts/data-ingress/data-privacy.md
@@ -14,7 +14,7 @@ The steps are as follows:
 2. They are prompted to sign a fixed message (the encryption seed) with their wallets, creating a unique signature that can only be recreated by signing that same message using that same wallet.
 3. The generated signature is used as the encryption key (EK) to encrypt the file F using a symmetric encryption technique, creating an encrypted file EF.
 4. The encryption key EK is then encrypted with the trusted party's public key, making an encrypted encryption key (EEK).
-5. The encrypted file EF and encrypted encryption key EEK can be safely shared with the intended receipient.
+5. The encrypted file EF and encrypted encryption key EEK can be safely shared with the intended recipient.
 
 ## Decrypting Data
 

--- a/core-concepts/network-overview/connectome.md
+++ b/core-concepts/network-overview/connectome.md
@@ -14,6 +14,6 @@ layout:
 
 # Connectome
 
-The Connectome is a decentralized ledger of real-time data transactions throughout Vana’s ecosystem. Using proof-of-stake consensus, Connectome [propogators](../roles/propagators.md) propagate [data transactions](../key-elements/data-transactions/) within the network. This ensures that DLP token transfers are valid and allows for cross-DLP data access by user-owned data applications.&#x20;
+The Connectome is a decentralized ledger of real-time data transactions throughout Vana’s ecosystem. Using proof-of-stake consensus, Connectome [propagators](../roles/propagators.md) propagate [data transactions](../key-elements/data-transactions/) within the network. This ensures that DLP token transfers are valid and allows for cross-DLP data access by user-owned data applications.&#x20;
 
 The Connectome allows external parties to view and monitor data transactions throughout the network. Moreover, the Connectome is EVM-compatible allowing for interoperability with other EVM networks, protocols, and DeFi applications.

--- a/other/faq.md
+++ b/other/faq.md
@@ -16,7 +16,7 @@ Vana addresses these challenges through:
 
 ### Why does data ownership help me as a builder?&#x20;
 
-Data ownership unlocks better AI by allowing access to new training datasets. Proper attribution and incentives enable frontier AI models collectively owned and governed by contributors with datasets that would otherwise be I walled gardensn. Data portability levels the playing field by allowing builders to access cross-platform data.&#x20;
+Data ownership unlocks better AI by allowing access to new training datasets. Proper attribution and incentives enable frontier AI models collectively owned and governed by contributors with datasets that would otherwise be I walled gardens. Data portability levels the playing field by allowing builders to access cross-platform data.&#x20;
 
 ### Why haven't any data ownership projects succeeded yet?
 


### PR DESCRIPTION
Fixed typos for clarity in the documentation. Hope this helps.

But in core-concepts/data-ingress/data-privacy.md file, It's hard to understand the exact meaning of ‘retreive’. If it's a typo, it should be ‘retrieve’. I've left it in because it's not clear typo or not.
